### PR TITLE
Add inline documentation

### DIFF
--- a/ml-backend/index.js
+++ b/ml-backend/index.js
@@ -1,3 +1,6 @@
+// Basic Express setup for the ML backend API. This file boots the
+// Node server, connects to MongoDB and wires up the WebSocket used for
+// streaming logs to the front end.
 const express = require('express')
 const mongoose = require('mongoose')
 const cors = require('cors')
@@ -15,6 +18,8 @@ app.use(express.json())
 
 app.use('/pipelines', pipelineRoutes)
 
+// Once the database connection succeeds we start the API server and the
+// WebSocket used for streaming training logs.
 mongoose
   .connect(process.env.MONGODB_URI)
   .then(() => {

--- a/ml-backend/ml_engine.py
+++ b/ml-backend/ml_engine.py
@@ -1,3 +1,11 @@
+"""Train a simple image classification model based on a pipeline description.
+
+The script reads a JSON payload from stdin describing the nodes and edges of
+the pipeline as well as the directory of extracted images. It outputs progress
+messages to stderr (forwarded to the browser via WebSocket) and finally emits a
+JSON result on stdout.
+"""
+
 import sys
 import os
 import json
@@ -12,6 +20,7 @@ from sklearn.preprocessing import LabelEncoder
 import traceback
 
 def extract_features(image_path):
+    """Convert an image to a flat grayscale feature vector."""
     try:
         img = Image.open(image_path).convert("L").resize((64, 64))
         return np.array(img).flatten()
@@ -20,6 +29,7 @@ def extract_features(image_path):
         return None
 
 def build_execution_order(nodes, edges):
+    """Return node ids in topological order to respect dependencies."""
     graph = defaultdict(list)
     in_degree = {node['id']: 0 for node in nodes}
     for edge in edges:
@@ -40,6 +50,7 @@ def build_execution_order(nodes, edges):
     return order
 
 def run_pipeline(image_dir, nodes, edges):
+    """Execute the pipeline and train a RandomForest model."""
     print("Starting ML pipeline execution...", file=sys.stderr, flush=True)
 
     image_paths, labels = [], []
@@ -122,6 +133,7 @@ def run_pipeline(image_dir, nodes, edges):
     sys.stdout.flush()
 
 def main():
+    """Entry point for reading payload from stdin and running the pipeline."""
     try:
         input_data = sys.stdin.read()
         payload = json.loads(input_data)

--- a/ml-backend/predict.py
+++ b/ml-backend/predict.py
@@ -1,3 +1,5 @@
+"""Run inference on a single image using the trained model."""
+
 import sys
 import json
 import os
@@ -7,6 +9,7 @@ import joblib
 import traceback
 
 def preprocess_image(path):
+    """Load an image and convert it to the format expected by the model."""
     try:
         print("Preprocessing image...", file=sys.stderr, flush=True)
         img = Image.open(path).convert('L')  # Grayscale
@@ -18,6 +21,7 @@ def preprocess_image(path):
         raise RuntimeError(f"Image preprocessing failed: {e}")
 
 def main():
+    """Load the trained model and output a prediction for one image."""
     try:
         print("Starting prediction script...", file=sys.stderr, flush=True)
 
@@ -35,7 +39,7 @@ def main():
 
         print(f" Image path received: {image_path}", file=sys.stderr, flush=True)
 
-        # Load model and encoder
+        # Load model and label encoder saved during training.
         base_dir = os.path.dirname(__file__)
         model_path = os.path.join(base_dir, 'uploads', 'model.pkl')
         encoder_path = os.path.join(base_dir, 'uploads', 'label_encoder.pkl')

--- a/src/pages/Deployment.jsx
+++ b/src/pages/Deployment.jsx
@@ -1,3 +1,5 @@
+// Page showing results of the last pipeline run and allowing single-image
+// predictions using the trained model.
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import api from '../api/api'
@@ -10,6 +12,8 @@ const Deployment = () => {
   const [predictedClass, setPredictedClass] = useState('')
   const [isPredicting, setIsPredicting] = useState(false)
 
+  // Load the output of the most recent pipeline execution from localStorage
+  // so the user can view results after a page refresh.
   useEffect(() => {
     try {
       const data = localStorage.getItem('pipelineOutput')
@@ -24,6 +28,8 @@ const Deployment = () => {
   }, [])
 
   const handleFileChange = (event) => {
+    // Store the chosen image locally so it can be previewed and sent to the
+    // backend for prediction.
     const file = event.target.files[0]
     if (file) {
       setSelectedFile(file)
@@ -33,6 +39,8 @@ const Deployment = () => {
   }
 
   const handlePredict = async () => {
+    // Submit the selected image to the backend prediction endpoint and
+    // display the returned class label.
     if (!selectedFile) {
       alert('Please select an image to predict.')
       return

--- a/src/pages/Pipeline.jsx
+++ b/src/pages/Pipeline.jsx
@@ -1,3 +1,6 @@
+// Visual editor page where users build and execute their ML pipeline. Nodes
+// are dragged onto a canvas and the resulting graph is sent to the backend for
+// training.
 import React, { useCallback, useRef, useState, useEffect } from 'react'
 import ReactFlow, {
   ReactFlowProvider,
@@ -12,6 +15,8 @@ import 'reactflow/dist/style.css'
 import styled from 'styled-components'
 import api from '../api/api'
 
+// Available pipeline steps users can drag into the canvas. Each entry defines
+// a label and a background color for the node.
 const nodeTypes = {
   dataIngestion: {
     label: 'Data Ingestion',
@@ -76,6 +81,8 @@ const Pipeline = () => {
   const [trainingProgress, setTrainingProgress] = useState(0)
   const [logs, setLogs] = useState([])
 
+  // Connect to the backend WebSocket to receive real-time logs during
+  // training.
   useEffect(() => {
     const ws = new WebSocket('ws://localhost:5000')
     ws.onmessage = (event) => {
@@ -119,6 +126,8 @@ const Pipeline = () => {
   )
 
   const handleFileUpload = async (e) => {
+    // Users upload a ZIP containing labeled image folders. The backend
+    // extracts it to prepare training data.
     const file = e.target.files[0]
     if (!file || !file.name.endsWith('.zip')) {
       alert('Please upload a .zip file with labeled image folders.')
@@ -146,6 +155,8 @@ const Pipeline = () => {
   }
 
   const executePipeline = async () => {
+    // Sends the current graph to the backend which runs ml_engine.py
+    // and streams logs back via WebSocket.
     if (nodes.length === 0) {
       alert('Please add nodes to execute the pipeline.')
       return
@@ -163,6 +174,7 @@ const Pipeline = () => {
   }
 
   const savePipeline = async () => {
+    // Store the current pipeline graph in MongoDB so it can be reused later.
     if (nodes.length === 0) {
       alert('Cannot save an empty pipeline!')
       return
@@ -182,6 +194,8 @@ const Pipeline = () => {
   }
 
   const loadPipeline = async () => {
+    // Fetch previously saved pipelines from the backend and let the user
+    // choose one to load into the editor.
     try {
       const response = await api.get('/pipelines/all')
       const pipelines = response.data


### PR DESCRIPTION
## Summary
- clarify purpose of backend server and routers
- document Python training and prediction scripts
- annotate React pages with explanations

## Testing
- `npm run lint` *(fails: `require` is not defined)*

